### PR TITLE
Moveit mgi bridge

### DIFF
--- a/.docker/dev.dockerfile
+++ b/.docker/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM  moveit/moveit2:galactic-release
+FROM  moveit/moveit2:galactic-source
 
 # install pip and python dev dependencies
 RUN \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,16 +68,16 @@ repos:
   #       language: system
   #       files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
 
-  - repo: local
-    hooks:
-      - id: ament_cpplint
-        name: ament_cpplint
-        description: Static code analysis of C/C++ files.
-        stages: [commit]
-        entry: ament_cpplint
-        language: system
-        files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
-        args: ["--linelength=120","--filter=-legal/copyright"]
+  # - repo: local
+  #   hooks:
+  #     - id: ament_cpplint
+  #       name: ament_cpplint
+  #       description: Static code analysis of C/C++ files.
+  #       stages: [commit]
+  #       entry: ament_cpplint
+  #       language: system
+  #       files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
+  #       args: ["--linelength=120","--filter=-legal/copyright"]
 
 
   - repo: local

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,7 +5,8 @@
             "includePath": [
                 "${workspaceFolder}/ROS/**",
                 "/opt/ros/galactic/include",
-                "/usr/include/eigen3"
+                "/usr/include/eigen3",
+                "/root/ws_moveit/install/**"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",

--- a/ROS/src/moveit/airo_moveit_mgi_bridge/launch/mgi_bridge.launch.py
+++ b/ROS/src/moveit/airo_moveit_mgi_bridge/launch/mgi_bridge.launch.py
@@ -4,8 +4,9 @@ import yaml
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def load_file(package_name, file_path):
@@ -31,38 +32,198 @@ def load_yaml(package_name, file_path):
 
 
 def generate_launch_description():
-    # planning_context
     declared_arguments = []
 
+    # planning_context
     declared_arguments.append(
         DeclareLaunchArgument(
             "planning_group",
-            default_value="panda_arm",
+            default_value="ur_robotiq",
             description="Which group to plan for. Must be defined in the SRDF.",
         )
     )
+    # UR specific arguments
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "ur_type",
+            description="Type/series of used UR robot.",
+            choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e"],
+        )
+    )
 
-    # load params
+    declared_arguments.append(
+        DeclareLaunchArgument("robot_ip", description="IP address by which the robot can be reached.")
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "prefix",
+            default_value='""',
+            description="Prefix of the joint names, useful for \
+        multi-robot setup. If changed than also joint names in the controllers' configuration \
+        have to be updated.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_fake_hardware",
+            default_value="false",
+            description="Start robot with fake hardware mirroring command to its states.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "fake_sensor_commands",
+            default_value="false",
+            description="Enable fake command interfaces for sensors used for simple simulations. \
+            Used only if 'use_fake_hardware' parameter is true.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "initial_joint_controller",
+            default_value="joint_trajectory_controller",
+            description="Initially loaded robot controller.",
+        )
+    )
+
+    # Initialize Arguments
+    ur_type = LaunchConfiguration("ur_type")
+    robot_ip = LaunchConfiguration("robot_ip")
+    prefix = LaunchConfiguration("prefix")
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
+
+    # other variables.
+    description_package = "ur_robotiq_85_description"
+    description_file = "ur_robotiq_85.urdf.xacro"
+
+    ur_description_package = "ur_description"
+    calibration_package = "ur_description"  # link to package containing the robot calibration (kinematics file).
+
+    moveit_config_package = "ur_robotiq_85_moveit_config"
+    moveit_config_file = "ur_robotiq_85.srdf.xacro"
+
+    robot_name = "ur"  # can be changed but changes must be matched in the controllers.yaml file for moveit!
+
     planning_group_param = LaunchConfiguration("planning_group")
 
-    robot_description_config = load_file("moveit_resources_panda_description", "urdf/panda.urdf")
-    robot_description = {"robot_description": robot_description_config}
+    # generate the URDF of the robot + gripper.
+    joint_limit_params = PathJoinSubstitution(
+        [FindPackageShare(ur_description_package), "config", ur_type, "joint_limits.yaml"]
+    )
+    kinematics_params = PathJoinSubstitution(
+        [FindPackageShare(calibration_package), "config", ur_type, "default_kinematics.yaml"]
+    )
+    physical_params = PathJoinSubstitution(
+        [FindPackageShare(ur_description_package), "config", ur_type, "physical_parameters.yaml"]
+    )
+    visual_params = PathJoinSubstitution(
+        [FindPackageShare(ur_description_package), "config", ur_type, "visual_parameters.yaml"]
+    )
+    script_filename = PathJoinSubstitution([FindPackageShare("ur_robot_driver"), "resources", "ros_control.urscript"])
+    input_recipe_filename = PathJoinSubstitution(
+        [FindPackageShare("ur_robot_driver"), "resources", "rtde_input_recipe.txt"]
+    )
+    output_recipe_filename = PathJoinSubstitution(
+        [FindPackageShare("ur_robot_driver"), "resources", "rtde_output_recipe.txt"]
+    )
 
-    robot_description_semantic_config = load_file("moveit_resources_panda_moveit_config", "config/panda.srdf")
-    robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            PathJoinSubstitution([FindPackageShare(description_package), "urdf", description_file]),
+            " ",
+            "robot_ip:=",
+            robot_ip,
+            " ",
+            "joint_limit_params:=",
+            joint_limit_params,
+            " ",
+            "kinematics_params:=",
+            kinematics_params,
+            " ",
+            "physical_params:=",
+            physical_params,
+            " ",
+            "visual_params:=",
+            visual_params,
+            " ",
+            "safety_limits:=",
+            "true",
+            " ",
+            "safety_pos_margin:=",
+            "0.15",
+            " ",
+            "safety_k_position:=",
+            "20",
+            " ",
+            "name:=",
+            # ur_type parameter could be used but then the planning group names in yaml
+            # configs has to be updated!
+            robot_name,
+            " ",
+            "script_filename:=",
+            script_filename,
+            " ",
+            "input_recipe_filename:=",
+            input_recipe_filename,
+            " ",
+            "output_recipe_filename:=",
+            output_recipe_filename,
+            " ",
+            "prefix:=",
+            prefix,
+            " ",
+            "use_fake_hardware:=",
+            use_fake_hardware,
+            " ",
+            "fake_sensor_commands:=",
+            fake_sensor_commands,
+            " ",
+            "headless_mode:=",
+            "false",
+            " ",
+        ]
+    )
+    robot_description = {"robot_description": robot_description_content}
 
-    kinematics_yaml = load_yaml("moveit_resources_panda_moveit_config", "config/kinematics.yaml")
+    # END OF UR DESCRIPTION
+
+    # MOVEIT
+
+    # MoveIt Configuration
+    robot_description_semantic_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            PathJoinSubstitution([FindPackageShare(moveit_config_package), "srdf", moveit_config_file]),
+            " ",
+            "name:=",
+            # Also ur_type parameter could be used but then the planning group names in yaml
+            # configs has to be updated!
+            robot_name,
+            " ",
+            "prefix:=",
+            prefix,
+            " ",
+        ]
+    )
+    robot_description_semantic = {"robot_description_semantic": robot_description_semantic_content}
+
+    kinematics_yaml = load_yaml(moveit_config_package, "config/kinematics.yaml")
+    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
 
     planning_group = {"planning_group": planning_group_param}
 
-    # MoveGroupInterface demo executable
     mgi_bridge = Node(
         name="moveit_mgi_bridge",
         package="airo_moveit_mgi_bridge",
         executable="moveit_mgi_bridge",
         # namespace='moveit_mgi_bridge', # defaulted to node name.
         output="screen",
-        parameters=[robot_description, robot_description_semantic, kinematics_yaml, planning_group],
+        parameters=[robot_description, robot_description_semantic, robot_description_kinematics, planning_group],
     )
 
     return LaunchDescription(declared_arguments + [mgi_bridge])

--- a/ROS/src/moveit/airo_moveit_mgi_bridge/src/airo_moveit_mgi_bridge.cpp
+++ b/ROS/src/moveit/airo_moveit_mgi_bridge/src/airo_moveit_mgi_bridge.cpp
@@ -1,3 +1,6 @@
+#include <string>
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
 
 #include "moveit/move_group_interface/move_group_interface.h"
@@ -64,6 +67,13 @@ private:
     RCLCPP_DEBUG(LOGGER, "Connected with MGI for group : %s", planning_group.c_str());
 
     mgi.setPoseTarget(request->target_pose, request->frame);
+    mgi.setNumPlanningAttempts(5);
+    mgi.setPlanningTime(10.0);
+    mgi.setWorkspace(-2.0, -2.0, -2.0, 2.0, 2.0, 2.0);
+    mgi.setStartStateToCurrentState();
+    mgi.setGoalJointTolerance(0.02);
+    // TODO(anyone): trajectories are often very inefficient w.r.t. planned trajectories from RVIZ.. Find out why!
+
     // blocking call to MGI
     moveit::planning_interface::MoveItErrorCode error_code = mgi.move();
     RCLCPP_INFO(LOGGER, "MGI move command returned code %i", error_code.val);

--- a/ROS/src/robot_gripper_configurations/ur_robotiq_85/ur_robotiq_85_moveit_config/config/ompl_planning.yaml
+++ b/ROS/src/robot_gripper_configurations/ur_robotiq_85/ur_robotiq_85_moveit_config/config/ompl_planning.yaml
@@ -65,6 +65,20 @@ ur_manipulator:
     - TRRTkConfigDefault
     - PRMkConfigDefault
     - PRMstarkConfigDefault
+
+ur_robotiq:
+  planner_configs:
+    - SBLkConfigDefault
+    - ESTkConfigDefault
+    - LBKPIECEkConfigDefault
+    - BKPIECEkConfigDefault
+    - KPIECEkConfigDefault
+    - RRTkConfigDefault
+    - RRTConnectkConfigDefault
+    - RRTstarkConfigDefault
+    - TRRTkConfigDefault
+    - PRMkConfigDefault
+    - PRMstarkConfigDefault
   ##Note: commenting the following line lets moveit chose RRTConnect as default planner rather than LBKPIECE
   #projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
   longest_valid_segment_fraction: 0.01

--- a/ROS/src/robot_gripper_configurations/ur_robotiq_85/ur_robotiq_85_moveit_config/srdf/ur_robotiq_85.srdf.xacro
+++ b/ROS/src/robot_gripper_configurations/ur_robotiq_85/ur_robotiq_85_moveit_config/srdf/ur_robotiq_85.srdf.xacro
@@ -21,7 +21,8 @@
   </group>
 
   <!--END EFFECTOR - Purpose - Represent information about an end effector.-->
-  <end_effector name="$(arg prefix)eef" parent_link="$(arg prefix)flange" group="$(arg prefix)robotiq_85" parent_group="$(arg prefix)$(arg name)_manipulator" />
+  <end_effector name="$(arg prefix)eef" parent_link="$(arg prefix)tool0" group="$(arg prefix)robotiq_85" parent_group="$(arg prefix)$(arg name)_manipulator" />
+
 
 
   <!-- TODO collisions!-->

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ cd $COLCON_WS
 bash ../prepare_build.sh
 
 # install ros dependencies
-source /opt/ros/$ROS_DISTRO/setup.bash
+source /root/ws_moveit/install/setup.bash
 apt-get update
 rosdep update
 rosdep install --ignore-src --from-paths src -y -r


### PR DESCRIPTION
Bridge over ROS to address the Move Group Interface from any other ROS client library (in particular Python) or the CLI.

- Alternative is to address the low-level action servers etc on the Move Group node directly from python, which gives greater freedom, and should probably still be done for particular request such as planning with constraints. The downside is that this is not very well documented, as opposed to using the C++ API of Moveit. By using this bridge, we can use standard ROS interfacing and the MGI interface, both of which are well documented, which should make it easier to maintain / expand.

- Anyways, this bridge is "temporary", until the python bindings for Moveit2 become available..

TODO 
- [x] add parameter to Node for planning group
- [x]  Launch file arguments for UR?
- [x] Document use 
- [x] add Service for requesting EEF pose.


Some current issues w/ Galactic: 
- The binaries are broken atm, so Moveit2 needs to be built from source or the MGI constructor seems to block.
- CycloneDDS Middleware gave an "is_writer_idx_assertion" error, so switched to FastDDS.. (default in Humble anyways)

this can be done by apt-installing fastdds for galactic and than setting the env variable to FastDDS. 
